### PR TITLE
feat: add ability to specify resource name and filter based on labels

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,4 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+on:
+  push:
+  pull_request:
+
+jobs:  
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: 1.68.0
+
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Run tests
+        run: cargo test --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bpaf"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "423bafba382cc2c561f486bfcae41c6692833eaff0a631d10c37a9489ccd3783"
+dependencies = [
+ "bpaf_derive",
+]
+
+[[package]]
+name = "bpaf_derive"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae9ee23ce08bc40839a8153f4b873fcfa08405221ed2cd9a4968d1a94ad83234"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +886,7 @@ dependencies = [
 name = "resource-status"
 version = "0.1.0"
 dependencies = [
+ "bpaf",
  "derive",
  "k8s-openapi",
  "kube",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,16 @@
 name = "resource-status"
 version = "0.1.0"
 edition = "2021"
+authors = ["nothinux <nothinux@gmail.com>"]
+description = "A tool that provide kubernetes cluster resource information, including cpu, memory, storage and number of pods."
+homepage = "https://github.com/nothinux/kube-resource-status"
+repository = "https://github.com/nothinux/kube-resource-status"
+readme = "./README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bpaf = { version = "0.7.10", features = ["derive"] }
 derive = "1.0.0"
 k8s-openapi = { version = "0.17.0", features = ["v1_24"] }
 kube = { version = "0.80.0", features = ["default"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,36 @@
+use std::str::FromStr;
+
+use bpaf::Bpaf;
 use kube::{Client};
 use tabled::{Table, Style};
 
-#[cfg(test)]
-mod utils_test;
+#[derive(Clone, Debug, Bpaf)]
+#[bpaf(options, version)]
+/// a tool that provide kubernetes cluster resource information, including cpu, memory, storage and number of pods.
+struct Options {
+    #[bpaf(short('l'), long)]
+    /// filter spesific node using it's label
+    selector: Option<String>,
+    #[bpaf(short('t'), long("type"))]
+    /// filter based on resource type (eg: node, namespace), default: node
+    resource_type: Option<String>,
+}
+
 mod utils;
 mod kubernetes;
 
+#[cfg(test)]
+mod utils_test;
+
 #[tokio::main]
 async fn main() {
+    let opts = options().run();
+    let mut resource_type: kubernetes::ResourceType = kubernetes::ResourceType::Node;
+
+    if let Some(rt) = opts.resource_type {
+        resource_type =  kubernetes::ResourceType::from_str(&rt).unwrap();
+    }
+
     let client = match Client::try_default().await {
         Err(e) => {
             eprintln!("Error creating kubernetes client {:?}", e);
@@ -18,7 +41,7 @@ async fn main() {
 
     let mut resource_req = Vec::new();
 
-    kubernetes::collect_node_info(client.clone(), &mut resource_req).await;
+    kubernetes::collect_info(client.clone(), &mut resource_req, resource_type, opts.selector).await;
 
     let data = utils::parse_resource_data(&resource_req);
     let mut table = Table::new(&data);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,7 +9,7 @@ pub fn parse_resource_data(rrs: &Vec<kubernetes::ResouceRequests>) -> Vec<kubern
         let storage_total = (rr.storage_requests / rr.storage_total) * 100.0;
 
         let rs = kubernetes::ResourceStatus::new(
-            format!("{}", rr.node_name),
+            format!("{}", rr.name),
             format!("{}m ({:.2}%)", rr.cpu_requests, cpu_total),
             format!("{}Mi ({:.2}%)", rr.mem_requests, mem_total),
             format!("{}Mi ({:.2}%)", rr.storage_requests, storage_total),


### PR DESCRIPTION
Currently, kube-resource-status could only show node information, and there's no capability to filter the nodes based on labels.

This PR adds support to filter the nodes based on labels and also adds a capability to show information based on namespaces.